### PR TITLE
Quietly `cargo run` on `build_tool`

### DIFF
--- a/run_rust_tool.cmd
+++ b/run_rust_tool.cmd
@@ -22,4 +22,4 @@ if errorlevel 1 (
     exit 1
 )
 
-cargo run --manifest-path=%BASEDIR%/build_tool/Cargo.toml --bin build_tool --target-dir=%CARGOKIT_TOOL_TEMP_DIR% -- %*
+cargo run --manifest-path=%BASEDIR%/build_tool/Cargo.toml --bin build_tool --target-dir=%CARGOKIT_TOOL_TEMP_DIR% --quiet -- %*

--- a/run_rust_tool.sh
+++ b/run_rust_tool.sh
@@ -22,4 +22,4 @@ then
     exit 1
 fi
 
-cargo run --manifest-path=$BASEDIR/build_tool/Cargo.toml --bin build_tool --target-dir=$CARGOKIT_TOOL_TEMP_DIR -- $@
+cargo run --manifest-path=$BASEDIR/build_tool/Cargo.toml --bin build_tool --target-dir=$CARGOKIT_TOOL_TEMP_DIR --quiet -- $@


### PR DESCRIPTION
https://github.com/cunarist/rust-in-flutter/issues/59

There was an issue asking why the custom Rust crate is built in debug mode, even in release mode. It turned out this misconception was because of that debug info being printed out was actually from the `build_tool` crate of cargokit, not the custom Rust crate. It would be nice to gracefully hide the `build_tool` compiling info IMHO :)