### PR TITLE
fix: cargo run will fail if the base dir contains a space

### DIFF
--- a/run_rust_tool.cmd
+++ b/run_rust_tool.cmd
@@ -22,4 +22,4 @@ if errorlevel 1 (
     exit 1
 )
 
-rustup run stable cargo run --manifest-path=%BASEDIR%/build_tool/Cargo.toml --bin build_tool --target-dir=%CARGOKIT_TOOL_TEMP_DIR% --quiet -- %*
+rustup run stable cargo run --manifest-path="%BASEDIR%/build_tool/Cargo.toml" --bin build_tool --target-dir="%CARGOKIT_TOOL_TEMP_DIR%" --quiet -- %*

--- a/run_rust_tool.sh
+++ b/run_rust_tool.sh
@@ -18,4 +18,4 @@ then
     exit 1
 fi
 
-rustup run stable cargo run --manifest-path=$BASEDIR/build_tool/Cargo.toml --bin build_tool --target-dir=$CARGOKIT_TOOL_TEMP_DIR --quiet -- $@
+rustup run stable cargo run --manifest-path="$BASEDIR/build_tool/Cargo.toml" --bin build_tool --target-dir="$CARGOKIT_TOOL_TEMP_DIR" --quiet -- $@


### PR DESCRIPTION
The cargo run will fail If the BASEDIR contains a space in windows.