### PR TITLE
feat: add workaround for pub path resolving bug

### DIFF
--- a/build_pod.sh
+++ b/build_pod.sh
@@ -3,6 +3,9 @@ set -e
 
 BASEDIR=$(dirname "$0")
 
+# Workaround for https://github.com/dart-lang/pub/issues/4010
+BASEDIR=$(cd "$BASEDIR" ; pwd -P)
+
 # Remove XCode SDK from path. Otherwise this breaks tool compilation when building iOS project
 NEW_PATH=`echo $PATH | tr ":" "\n" | grep -v "Contents/Developer/" | tr "\n" ":"`
 

--- a/cmake/cargokit.cmake
+++ b/cmake/cargokit.cmake
@@ -1,5 +1,13 @@
 SET(cargokit_cmake_root "${CMAKE_CURRENT_LIST_DIR}/..")
 
+# Workaround for https://github.com/dart-lang/pub/issues/4010
+get_filename_component(cargokit_cmake_root "${cargokit_cmake_root}" REALPATH)
+
+if(WIN32)
+    # REALPATH does not properly resolve symlinks on windows :-/
+    execute_process(COMMAND powershell -File "${CMAKE_CURRENT_LIST_DIR}/resolve_symlinks.ps1" "${cargokit_cmake_root}" OUTPUT_VARIABLE cargokit_cmake_root OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+
 # Arguments
 # - target: CMAKE target to which rust library is linked
 # - manifest_dir: relative path from current folder to directory containing cargo manifest

--- a/cmake/resolve_symlinks.ps1
+++ b/cmake/resolve_symlinks.ps1
@@ -1,0 +1,27 @@
+function Resolve-Symlinks {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Position = 0, Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [string] $Path
+    )
+
+    [string] $separator = '/'
+    [string[]] $parts = $Path.Split($separator)
+
+    [string] $realPath = ''
+    foreach ($part in $parts) {
+        if ($realPath -and !$realPath.EndsWith($separator)) {
+            $realPath += $separator
+        }
+        $realPath += $part
+        $item = Get-Item $realPath
+        if ($item.Target) {
+            $realPath = $item.Target.Replace('\', '/')
+        }
+    }
+    $realPath
+}
+
+$path=Resolve-Symlinks -Path $args[0]
+Write-Host $path


### PR DESCRIPTION
Pub issue: https://github.com/dart-lang/pub/issues/4010

This has been merged but will likely take a while until it trickles down to Flutter stable so in the meanwhile the workaround will resolve the symlink before feeding it to pub.

Fixes https://github.com/irondash/cargokit/issues/14