### PR TITLE
Fix build mode when using a flutter flavor

### DIFF
--- a/gradle/plugin.gradle
+++ b/gradle/plugin.gradle
@@ -141,7 +141,7 @@ class CargoKitPlugin implements Plugin<Project> {
                 }
 
                 def task = project.tasks.create(taskName, CargoKitBuildTask.class) {
-                    buildMode = variant.name
+                    buildMode = variant.buildType.name
                     buildDir = cargoBuildDir
                     outputDir = cargoOutputDir
                     ndkVersion = plugin.project.android.ndkVersion


### PR DESCRIPTION
plugin.gradle: Use variant.buildType.name instead of variant.name.
The latter is equal to flavor + buildMode while the former is just buildMode

It fixes this issue https://github.com/fzyzcjy/flutter_rust_bridge/issues/1606