### PR TITLE
fix: add `/D` argument for cd to trigger drive change when changing directory

### DIFF
--- a/run_build_tool.cmd
+++ b/run_build_tool.cmd
@@ -8,7 +8,7 @@ SET BASEDIR=%~dp0
 if not exist "%CARGOKIT_TOOL_TEMP_DIR%" (
     mkdir "%CARGOKIT_TOOL_TEMP_DIR%"
 )
-cd "%CARGOKIT_TOOL_TEMP_DIR%"
+cd /D "%CARGOKIT_TOOL_TEMP_DIR%"
 
 SET BUILD_TOOL_PKG_DIR=%BASEDIR%build_tool
 SET DART=%FLUTTER_ROOT%\bin\cache\dart-sdk\bin\dart


### PR DESCRIPTION
When gradle plugin runs [run_build_tool.cmd](https://github.com/irondash/cargokit/blob/a3b7352f9ebea0108d144c26437138f2903d6b35/run_build_tool.cmd) it passes to script env variable `%CARGOKIT_TOOL_TEMP_DIR%`. Then script make `cd` to dir that passed inside this variable. But if this variable points to directory that located on different drive than working directory for script, cd will not work. For it to work we need to pass `/D` parameter to `cd`. I made this change localy and it helps. Right now line [11](https://github.com/irondash/cargokit/blob/a3b7352f9ebea0108d144c26437138f2903d6b35/run_build_tool.cmd#L11) in local my script looks like:
```
cd /D "%CARGOKIT_TOOL_TEMP_DIR%"
```
and it works.

This is PR that fix this issue.


PS:
[my inital issue](https://github.com/superlistapp/super_native_extensions/issues/290)