### PR TITLE
fix: use alias for shasum if sha1sum is found instead

### DIFF
--- a/run_build_tool.sh
+++ b/run_build_tool.sh
@@ -42,6 +42,12 @@ void main(List<String> args) {
 }
 EOF
 
+# Create alias for `shasum` if it does not exist and `sha1sum` exists
+if ! [ -x "$(command -v shasum)" ] && [ -x "$(command -v sha1sum)" ]; then
+  shopt -s expand_aliases
+  alias shasum="sha1sum"
+fi
+
 # Dart run will not cache any package that has a path dependency, which
 # is the case for our build_tool_runner. So instead we precompile the package
 # ourselves.


### PR DESCRIPTION
Some Linux distributions might have `sha1sum` in the path but `shasum` might be missing.
This will create an alias for `shasum` to fallback to `sha1sum` if available.

Should close #57 