### PR TITLE
fix insufficient sh permissions

### DIFF
--- a/build_pod.sh
+++ b/build_pod.sh
@@ -49,7 +49,7 @@ do
   fi
 done
 
-"$BASEDIR/run_build_tool.sh" build-pod "$@"
+sh "$BASEDIR/run_build_tool.sh" build-pod "$@"
 
 # Make a symlink from built framework to phony file, which will be used as input to
 # build script. This should force rebuild (podspec currently doesn't support alwaysOutOfDate

--- a/cmake/cargokit.cmake
+++ b/cmake/cargokit.cmake
@@ -50,6 +50,7 @@ function(apply_cargokit target manifest_dir lib_name any_symbol_name)
     else()
         set(SCRIPT_EXTENSION ".sh")
         set(IMPORT_LIB_EXTENSION "")
+        execute_process(COMMAND chmod +x "${cargokit_cmake_root}/run_build_tool${SCRIPT_EXTENSION}")
     endif()
 
     # Using generators in custom command is only supported in CMake 3.20+
@@ -74,6 +75,7 @@ function(apply_cargokit target manifest_dir lib_name any_symbol_name)
             VERBATIM
         )
     endif()
+
 
     set_source_files_properties("${CMAKE_CURRENT_BINARY_DIR}/_phony_" PROPERTIES SYMBOLIC TRUE)
 

--- a/gradle/plugin.gradle
+++ b/gradle/plugin.gradle
@@ -55,7 +55,13 @@ abstract class CargoKitBuildTask extends DefaultTask {
         def manifestDir = Paths.get(project.buildscript.sourceFile.parent, project.cargokit.manifestDir)
 
         def rootProjectDir = project.rootProject.projectDir
-
+        
+        if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
+            project.exec {
+                commandLine 'chmod', '+x', path
+            }
+        }
+        
         project.exec {
             executable path
             args "build-gradle"


### PR DESCRIPTION
Origin issue: https://github.com/fzyzcjy/flutter_rust_bridge/issues/1840
Origin pr: https://github.com/fzyzcjy/flutter_rust_bridge/pull/1842

Simple problem description: if you create a new flutter_rust project in windows, the sh script is automatically created, but the executable permissions cannot be set. When moving this project to macOS and executing `flutter build ios` to build ipa files the process crashes due to insufficient sh script permissions.

This permission problem can be circumvented by `sh script.sh` rather than `script.sh`

As verified by Github Action's macOS Runner, the modified cargokit works fine for building ipa apps using the flutter_rust project created on windows.

[Action Link](https://github.com/canxin121/new_app_test/actions/runs/8466294309)