### PR TITLE
chore: support build as a flutter module

### DIFF
--- a/.github/workflows/test_example_plugin_build.yml
+++ b/.github/workflows/test_example_plugin_build.yml
@@ -77,8 +77,10 @@ jobs:
         shell: bash
         working-directory: ${{ env.EXAMPLE_DIR }}
         run: |
-          export JAVA_HOME=$JAVA_HOME_11_X64
-          mkdir -p ~/.gradle
-          echo "org.gradle.java.home=$JAVA_HOME_11_X64" > ~/.gradle/gradle.properties
+          if [[ $(sysctl hw.optional.arm64) == *"hw.optional.arm64: 1"* ]]; then
+            export JAVA_HOME=$JAVA_HOME_11_arm64
+          else
+            export JAVA_HOME=$JAVA_HOME_11_X64
+          fi
           flutter build apk --${{ matrix.build_mode }} -v
 

--- a/.github/workflows/test_example_plugin_build.yml
+++ b/.github/workflows/test_example_plugin_build.yml
@@ -78,5 +78,7 @@ jobs:
         working-directory: ${{ env.EXAMPLE_DIR }}
         run: |
           export JAVA_HOME=$JAVA_HOME_11_X64
+          mkdir -p ~/.gradle
+          echo "org.gradle.java.home=$JAVA_HOME_11_X64" > ~/.gradle/gradle.properties
           flutter build apk --${{ matrix.build_mode }} -v
 

--- a/.github/workflows/test_example_plugin_build.yml
+++ b/.github/workflows/test_example_plugin_build.yml
@@ -78,7 +78,7 @@ jobs:
         working-directory: ${{ env.EXAMPLE_DIR }}
         run: |
           if [[ $(sysctl hw.optional.arm64) == *"hw.optional.arm64: 1"* ]]; then
-            export JAVA_HOME=$JAVA_HOME_11_arm64
+            export JAVA_HOME=$JAVA_HOME_17_arm64
           else
             export JAVA_HOME=$JAVA_HOME_11_X64
           fi

--- a/gradle/plugin.gradle
+++ b/gradle/plugin.gradle
@@ -116,8 +116,12 @@ class CargoKitPlugin implements Plugin<Project> {
         }
 
         def cargoBuildDir = "${project.buildDir}/build"
+        
+        // Determine if the project is an application or library
+        def isApplication = plugin.project.plugins.hasPlugin('com.android.application')
+        def variants = isApplication ? plugin.project.android.applicationVariants : plugin.project.android.libraryVariants
 
-        plugin.project.android.applicationVariants.all { variant ->
+        variants.all { variant ->
 
             final buildType = variant.buildType.name
 


### PR DESCRIPTION
When build as a flutter module and integrated into the existing android project, there is no applicationVariants and result in following compilation failure:

Could not get unknown property 'applicationVariants' for extension 'android' of type com.android.build.gradle.LibraryExtension.

In such case, we will use libraryVariants instead

https://github.com/superlistapp/super_native_extensions/issues/379