### PR TITLE
Fix the issue where symbolic links are not correctly resolved when using them to move the Flutter cache to another location.

### DIFF
--- a/cmake/resolve_symlinks.ps1
+++ b/cmake/resolve_symlinks.ps1
@@ -6,22 +6,15 @@ function Resolve-Symlinks {
         [string] $Path
     )
 
-    [string] $separator = '/'
-    [string[]] $parts = $Path.Split($separator)
-
-    [string] $realPath = ''
-    foreach ($part in $parts) {
-        if ($realPath -and !$realPath.EndsWith($separator)) {
-            $realPath += $separator
-        }
-        $realPath += $part
-        $item = Get-Item $realPath
-        if ($item.Target) {
-            $realPath = $item.Target.Replace('\', '/')
-        }
+    $Private:Item = Get-Item -LiteralPath $Path
+    if ([string]::IsNullOrEmpty($Private:Item.Target)) {
+        $Private:Parent = Resolve-Symlinks $Private:Item.Parent
+        return Join-Path $Private:Parent $Private:Item.Name
     }
-    $realPath
+    else {
+        return $Private:Item.Target
+    }
 }
 
-$path=Resolve-Symlinks -Path $args[0]
+$path = Resolve-Symlinks -Path $args[0]
 Write-Host $path


### PR DESCRIPTION
I will move the cache of Flutter from `%LocalAppData%\Pub` to `E:\Cache\Pub`
But this script cannot correctly parse this situation
It will change the address originally pointing to `E:\Cache\Pub` to `C:\Cache\Pub`, thereby preventing compilation


## Links
- Tienisto/rhttp#48