### PR TITLE
Riscv64 support & glibc version overriding

### DIFF
--- a/.github/workflows/check_and_lint.yml
+++ b/.github/workflows/check_and_lint.yml
@@ -16,8 +16,13 @@ jobs:
         run: dart pub get --no-precompile
         working-directory: build_tool
       - name: Dart Format
-        run: dart format . --output=none --set-exit-if-changed
+        run: dart format .
         working-directory: build_tool
+      - name: Upload Formatted Files
+        uses: actions/upload-artifact@v4
+        with:
+          name: formatted-files
+          path: .
       - name: Analyze
         run: dart analyze
         working-directory: build_tool

--- a/.github/workflows/check_and_lint.yml
+++ b/.github/workflows/check_and_lint.yml
@@ -16,13 +16,8 @@ jobs:
         run: dart pub get --no-precompile
         working-directory: build_tool
       - name: Dart Format
-        run: dart format .
+        run: dart format . --output=none --set-exit-if-changed
         working-directory: build_tool
-      - name: Upload Formatted Files
-        uses: actions/upload-artifact@v4
-        with:
-          name: formatted-files
-          path: .
       - name: Analyze
         run: dart analyze
         working-directory: build_tool

--- a/.github/workflows/check_and_lint.yml
+++ b/.github/workflows/check_and_lint.yml
@@ -16,13 +16,8 @@ jobs:
         run: dart pub get --no-precompile
         working-directory: build_tool
       - name: Dart Format
-        run: dart format . --output=none
+        run: dart format . --output=none --set-exit-if-changed
         working-directory: build_tool
-      - name: Upload Formatted Files
-        uses: actions/upload-artifact@v4
-        with:
-          name: formatted-files
-          path: .
       - name: Analyze
         run: dart analyze
         working-directory: build_tool

--- a/.github/workflows/check_and_lint.yml
+++ b/.github/workflows/check_and_lint.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # 4.1.0
       - uses: subosito/flutter-action@44ac965b96f18d999802d4b807e3256d5a3f9fa1 # 2.16.0
+      - name: test
+        run: dart format --version
       - name: Pub Get
         run: dart pub get --no-precompile
         working-directory: build_tool

--- a/.github/workflows/check_and_lint.yml
+++ b/.github/workflows/check_and_lint.yml
@@ -12,14 +12,17 @@ jobs:
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # 4.1.0
       - uses: subosito/flutter-action@44ac965b96f18d999802d4b807e3256d5a3f9fa1 # 2.16.0
-      - name: test
-        run: dart format --version
       - name: Pub Get
         run: dart pub get --no-precompile
         working-directory: build_tool
       - name: Dart Format
-        run: dart format . --output=none --set-exit-if-changed
+        run: dart format . --output=none
         working-directory: build_tool
+      - name: Upload Formatted Files
+        uses: actions/upload-artifact@v4
+        with:
+          name: formatted-files
+          path: .
       - name: Analyze
         run: dart analyze
         working-directory: build_tool

--- a/build_tool/lib/src/android_environment.dart
+++ b/build_tool/lib/src/android_environment.dart
@@ -22,18 +22,17 @@ class AndroidEnvironment {
     final clang = Platform.environment['_CARGOKIT_NDK_LINK_CLANG'];
     if (clang == null) {
       throw Exception(
-          "cargo-ndk rustc linker: didn't find _CARGOKIT_NDK_LINK_CLANG env var");
+        "cargo-ndk rustc linker: didn't find _CARGOKIT_NDK_LINK_CLANG env var",
+      );
     }
     final target = Platform.environment['_CARGOKIT_NDK_LINK_TARGET'];
     if (target == null) {
       throw Exception(
-          "cargo-ndk rustc linker: didn't find _CARGOKIT_NDK_LINK_TARGET env var");
+        "cargo-ndk rustc linker: didn't find _CARGOKIT_NDK_LINK_TARGET env var",
+      );
     }
 
-    runCommand(clang, [
-      target,
-      ...args,
-    ]);
+    runCommand(clang, [target, ...args]);
   }
 
   /// Full path to Android SDK.
@@ -57,9 +56,7 @@ class AndroidEnvironment {
     return ndkPackageXml.existsSync();
   }
 
-  void installNdk({
-    required String javaHome,
-  }) {
+  void installNdk({required String javaHome}) {
     final sdkManagerExtension = Platform.isWindows ? '.bat' : '';
     final sdkManager = path.join(
       sdkPath,
@@ -70,18 +67,18 @@ class AndroidEnvironment {
     );
 
     log.info('Installing NDK $ndkVersion');
-    runCommand(sdkManager, [
-      '--install',
-      'ndk;$ndkVersion',
-    ], environment: {
-      'JAVA_HOME': javaHome,
-    });
+    runCommand(
+      sdkManager,
+      ['--install', 'ndk;$ndkVersion'],
+      environment: {'JAVA_HOME': javaHome},
+    );
   }
 
   Future<Map<String, String>> buildEnvironment() async {
-    final hostArch = Platform.isMacOS
-        ? "darwin-x86_64"
-        : (Platform.isLinux ? "linux-x86_64" : "windows-x86_64");
+    final hostArch =
+        Platform.isMacOS
+            ? "darwin-x86_64"
+            : (Platform.isLinux ? "linux-x86_64" : "windows-x86_64");
 
     final ndkPath = path.join(sdkPath, 'ndk', ndkVersion);
     final toolchainPath = path.join(
@@ -93,8 +90,10 @@ class AndroidEnvironment {
       'bin',
     );
 
-    final minSdkVersion =
-        math.max(target.androidMinSdkVersion!, this.minSdkVersion);
+    final minSdkVersion = math.max(
+      target.androidMinSdkVersion!,
+      this.minSdkVersion,
+    );
 
     final exe = Platform.isWindows ? '.exe' : '';
 
@@ -131,16 +130,13 @@ class AndroidEnvironment {
     final runRustTool =
         Platform.isWindows ? 'run_build_tool.cmd' : 'run_build_tool.sh';
 
-    final packagePath = (await Isolate.resolvePackageUri(
-            Uri.parse('package:build_tool/buildtool.dart')))!
-        .toFilePath();
-    final selfPath = path.canonicalize(path.join(
-      packagePath,
-      '..',
-      '..',
-      '..',
-      runRustTool,
-    ));
+    final packagePath =
+        (await Isolate.resolvePackageUri(
+          Uri.parse('package:build_tool/buildtool.dart'),
+        ))!.toFilePath();
+    final selfPath = path.canonicalize(
+      path.join(packagePath, '..', '..', '..', runRustTool),
+    );
 
     // Make sure that run_build_tool is working properly even initially launched directly
     // through dart run.
@@ -173,13 +169,15 @@ class AndroidEnvironment {
     );
     Directory(workaroundDir).createSync(recursive: true);
     if (ndkVersion.major >= 23) {
-      File(path.join(workaroundDir, 'libgcc.a'))
-          .writeAsStringSync('INPUT(-lunwind)');
+      File(
+        path.join(workaroundDir, 'libgcc.a'),
+      ).writeAsStringSync('INPUT(-lunwind)');
     } else {
       // Other way around, untested, forward libgcc.a from libunwind once Rust
       // gets updated for NDK23+.
-      File(path.join(workaroundDir, 'libunwind.a'))
-          .writeAsStringSync('INPUT(-lgcc)');
+      File(
+        path.join(workaroundDir, 'libunwind.a'),
+      ).writeAsStringSync('INPUT(-lgcc)');
     }
 
     var rustFlags = Platform.environment['CARGO_ENCODED_RUSTFLAGS'] ?? '';

--- a/build_tool/lib/src/android_environment.dart
+++ b/build_tool/lib/src/android_environment.dart
@@ -75,10 +75,9 @@ class AndroidEnvironment {
   }
 
   Future<Map<String, String>> buildEnvironment() async {
-    final hostArch =
-        Platform.isMacOS
-            ? "darwin-x86_64"
-            : (Platform.isLinux ? "linux-x86_64" : "windows-x86_64");
+    final hostArch = Platform.isMacOS
+        ? "darwin-x86_64"
+        : (Platform.isLinux ? "linux-x86_64" : "windows-x86_64");
 
     final ndkPath = path.join(sdkPath, 'ndk', ndkVersion);
     final toolchainPath = path.join(
@@ -130,10 +129,10 @@ class AndroidEnvironment {
     final runRustTool =
         Platform.isWindows ? 'run_build_tool.cmd' : 'run_build_tool.sh';
 
-    final packagePath =
-        (await Isolate.resolvePackageUri(
-          Uri.parse('package:build_tool/buildtool.dart'),
-        ))!.toFilePath();
+    final packagePath = (await Isolate.resolvePackageUri(
+      Uri.parse('package:build_tool/buildtool.dart'),
+    ))!
+        .toFilePath();
     final selfPath = path.canonicalize(
       path.join(packagePath, '..', '..', '..', runRustTool),
     );

--- a/build_tool/lib/src/artifacts_provider.dart
+++ b/build_tool/lib/src/artifacts_provider.dart
@@ -75,16 +75,15 @@ class ArtifactProvider {
           remote: false,
         ),
       };
-      final artifacts =
-          artifactNames
-              .map(
-                (artifactName) => Artifact(
-                  path: path.join(targetDir, artifactName),
-                  finalFileName: artifactName,
-                ),
-              )
-              .where((element) => File(element.path).existsSync())
-              .toList();
+      final artifacts = artifactNames
+          .map(
+            (artifactName) => Artifact(
+              path: path.join(targetDir, artifactName),
+              finalFileName: artifactName,
+            ),
+          )
+          .where((element) => File(element.path).existsSync())
+          .toList();
       result[target] = artifacts;
     }
     return result;

--- a/build_tool/lib/src/build_cmake.dart
+++ b/build_tool/lib/src/build_cmake.dart
@@ -21,16 +21,19 @@ class BuildCMake {
     }
 
     final environment = BuildEnvironment.fromEnvironment(isAndroid: false);
-    final provider =
-        ArtifactProvider(environment: environment, userOptions: userOptions);
+    final provider = ArtifactProvider(
+      environment: environment,
+      userOptions: userOptions,
+    );
     final artifacts = await provider.getArtifacts([target]);
 
     final libs = artifacts[target]!;
 
     for (final lib in libs) {
       if (lib.type == AritifactType.dylib) {
-        File(lib.path)
-            .copySync(path.join(Environment.outputDir, lib.finalFileName));
+        File(
+          lib.path,
+        ).copySync(path.join(Environment.outputDir, lib.finalFileName));
       }
     }
   }

--- a/build_tool/lib/src/build_gradle.dart
+++ b/build_tool/lib/src/build_gradle.dart
@@ -17,18 +17,22 @@ class BuildGradle {
   final CargokitUserOptions userOptions;
 
   Future<void> build() async {
-    final targets = Environment.targetPlatforms.map((arch) {
-      final target = Target.forFlutterName(arch);
-      if (target == null) {
-        throw Exception(
-            "Unknown darwin target or platform: $arch, ${Environment.darwinPlatformName}");
-      }
-      return target;
-    }).toList();
+    final targets =
+        Environment.targetPlatforms.map((arch) {
+          final target = Target.forFlutterName(arch);
+          if (target == null) {
+            throw Exception(
+              "Unknown darwin target or platform: $arch, ${Environment.darwinPlatformName}",
+            );
+          }
+          return target;
+        }).toList();
 
     final environment = BuildEnvironment.fromEnvironment(isAndroid: true);
-    final provider =
-        ArtifactProvider(environment: environment, userOptions: userOptions);
+    final provider = ArtifactProvider(
+      environment: environment,
+      userOptions: userOptions,
+    );
     final artifacts = await provider.getArtifacts(targets);
 
     for (final target in targets) {

--- a/build_tool/lib/src/build_gradle.dart
+++ b/build_tool/lib/src/build_gradle.dart
@@ -17,16 +17,15 @@ class BuildGradle {
   final CargokitUserOptions userOptions;
 
   Future<void> build() async {
-    final targets =
-        Environment.targetPlatforms.map((arch) {
-          final target = Target.forFlutterName(arch);
-          if (target == null) {
-            throw Exception(
-              "Unknown darwin target or platform: $arch, ${Environment.darwinPlatformName}",
-            );
-          }
-          return target;
-        }).toList();
+    final targets = Environment.targetPlatforms.map((arch) {
+      final target = Target.forFlutterName(arch);
+      if (target == null) {
+        throw Exception(
+          "Unknown darwin target or platform: $arch, ${Environment.darwinPlatformName}",
+        );
+      }
+      return target;
+    }).toList();
 
     final environment = BuildEnvironment.fromEnvironment(isAndroid: true);
     final provider = ArtifactProvider(

--- a/build_tool/lib/src/build_pod.dart
+++ b/build_tool/lib/src/build_pod.dart
@@ -15,42 +15,45 @@ class BuildPod {
   final CargokitUserOptions userOptions;
 
   Future<void> build() async {
-    final targets = Environment.darwinArchs.map((arch) {
-      final target = Target.forDarwin(
-          platformName: Environment.darwinPlatformName, darwinAarch: arch);
-      if (target == null) {
-        throw Exception(
-            "Unknown darwin target or platform: $arch, ${Environment.darwinPlatformName}");
-      }
-      return target;
-    }).toList();
+    final targets =
+        Environment.darwinArchs.map((arch) {
+          final target = Target.forDarwin(
+            platformName: Environment.darwinPlatformName,
+            darwinAarch: arch,
+          );
+          if (target == null) {
+            throw Exception(
+              "Unknown darwin target or platform: $arch, ${Environment.darwinPlatformName}",
+            );
+          }
+          return target;
+        }).toList();
 
     final environment = BuildEnvironment.fromEnvironment(isAndroid: false);
-    final provider =
-        ArtifactProvider(environment: environment, userOptions: userOptions);
+    final provider = ArtifactProvider(
+      environment: environment,
+      userOptions: userOptions,
+    );
     final artifacts = await provider.getArtifacts(targets);
 
     void performLipo(String targetFile, Iterable<String> sourceFiles) {
-      runCommand("lipo", [
-        '-create',
-        ...sourceFiles,
-        '-output',
-        targetFile,
-      ]);
+      runCommand("lipo", ['-create', ...sourceFiles, '-output', targetFile]);
     }
 
     final outputDir = Environment.outputDir;
 
     Directory(outputDir).createSync(recursive: true);
 
-    final staticLibs = artifacts.values
-        .expand((element) => element)
-        .where((element) => element.type == AritifactType.staticlib)
-        .toList();
-    final dynamicLibs = artifacts.values
-        .expand((element) => element)
-        .where((element) => element.type == AritifactType.dylib)
-        .toList();
+    final staticLibs =
+        artifacts.values
+            .expand((element) => element)
+            .where((element) => element.type == AritifactType.staticlib)
+            .toList();
+    final dynamicLibs =
+        artifacts.values
+            .expand((element) => element)
+            .where((element) => element.type == AritifactType.dylib)
+            .toList();
 
     final libName = environment.crateInfo.packageName;
 

--- a/build_tool/lib/src/build_pod.dart
+++ b/build_tool/lib/src/build_pod.dart
@@ -15,19 +15,18 @@ class BuildPod {
   final CargokitUserOptions userOptions;
 
   Future<void> build() async {
-    final targets =
-        Environment.darwinArchs.map((arch) {
-          final target = Target.forDarwin(
-            platformName: Environment.darwinPlatformName,
-            darwinAarch: arch,
-          );
-          if (target == null) {
-            throw Exception(
-              "Unknown darwin target or platform: $arch, ${Environment.darwinPlatformName}",
-            );
-          }
-          return target;
-        }).toList();
+    final targets = Environment.darwinArchs.map((arch) {
+      final target = Target.forDarwin(
+        platformName: Environment.darwinPlatformName,
+        darwinAarch: arch,
+      );
+      if (target == null) {
+        throw Exception(
+          "Unknown darwin target or platform: $arch, ${Environment.darwinPlatformName}",
+        );
+      }
+      return target;
+    }).toList();
 
     final environment = BuildEnvironment.fromEnvironment(isAndroid: false);
     final provider = ArtifactProvider(
@@ -44,16 +43,14 @@ class BuildPod {
 
     Directory(outputDir).createSync(recursive: true);
 
-    final staticLibs =
-        artifacts.values
-            .expand((element) => element)
-            .where((element) => element.type == AritifactType.staticlib)
-            .toList();
-    final dynamicLibs =
-        artifacts.values
-            .expand((element) => element)
-            .where((element) => element.type == AritifactType.dylib)
-            .toList();
+    final staticLibs = artifacts.values
+        .expand((element) => element)
+        .where((element) => element.type == AritifactType.staticlib)
+        .toList();
+    final dynamicLibs = artifacts.values
+        .expand((element) => element)
+        .where((element) => element.type == AritifactType.dylib)
+        .toList();
 
     final libName = environment.crateInfo.packageName;
 

--- a/build_tool/lib/src/build_tool.dart
+++ b/build_tool/lib/src/build_tool.dart
@@ -109,8 +109,7 @@ class PrecompileBinariesCommand extends Command {
       )
       ..addMultiOption(
         'target',
-        help:
-            'Rust target triple of artifact to build.\n'
+        help: 'Rust target triple of artifact to build.\n'
             'Can be specified multiple times or omitted in which case\n'
             'all targets for current platform will be built.',
       )
@@ -146,8 +145,7 @@ class PrecompileBinariesCommand extends Command {
   final name = 'precompile-binaries';
 
   @override
-  final description =
-      'Prebuild and upload binaries\n'
+  final description = 'Prebuild and upload binaries\n'
       'Private key must be passed through PRIVATE_KEY environment variable. '
       'Use gen_key through generate priave key.\n'
       'Github token must be passed as GITHUB_TOKEN environment variable.\n';
@@ -187,15 +185,13 @@ class PrecompileBinariesCommand extends Command {
       }
     }
     final targetStrigns = argResults!['target'] as List<String>;
-    final targets = targetStrigns
-        .map((target) {
-          final res = Target.forRustTriple(target);
-          if (res == null) {
-            throw ArgumentError('Invalid target: $target');
-          }
-          return res;
-        })
-        .toList(growable: false);
+    final targets = targetStrigns.map((target) {
+      final res = Target.forRustTriple(target);
+      if (res == null) {
+        throw ArgumentError('Invalid target: $target');
+      }
+      return res;
+    }).toList(growable: false);
     final precompileBinaries = PrecompileBinaries(
       privateKey: PrivateKey(privateKey),
       githubToken: githubToken,
@@ -226,8 +222,7 @@ class VerifyBinariesCommand extends Command {
   final name = "verify-binaries";
 
   @override
-  final description =
-      'Verifies published binaries\n'
+  final description = 'Verifies published binaries\n'
       'Checks whether there is a binary published for each targets\n'
       'and checks the signature.';
 
@@ -248,14 +243,13 @@ Future<void> runMain(List<String> args) async {
       return AndroidEnvironment.clangLinkerWrapper(args);
     }
 
-    final runner =
-        CommandRunner('build_tool', 'Cargokit built_tool')
-          ..addCommand(BuildPodCommand())
-          ..addCommand(BuildGradleCommand())
-          ..addCommand(BuildCMakeCommand())
-          ..addCommand(GenKeyCommand())
-          ..addCommand(PrecompileBinariesCommand())
-          ..addCommand(VerifyBinariesCommand());
+    final runner = CommandRunner('build_tool', 'Cargokit built_tool')
+      ..addCommand(BuildPodCommand())
+      ..addCommand(BuildGradleCommand())
+      ..addCommand(BuildCMakeCommand())
+      ..addCommand(GenKeyCommand())
+      ..addCommand(PrecompileBinariesCommand())
+      ..addCommand(VerifyBinariesCommand());
 
     await runner.run(args);
   } on ArgumentError catch (e) {

--- a/build_tool/lib/src/builder.dart
+++ b/build_tool/lib/src/builder.dart
@@ -18,10 +18,10 @@ extension on BuildConfiguration {
   bool get isDebug => this == BuildConfiguration.debug;
 
   String get rustName => switch (this) {
-    BuildConfiguration.debug => 'debug',
-    BuildConfiguration.release => 'release',
-    BuildConfiguration.profile => 'release',
-  };
+        BuildConfiguration.debug => 'debug',
+        BuildConfiguration.release => 'release',
+        BuildConfiguration.profile => 'release',
+      };
 }
 
 class BuildException implements Exception {
@@ -131,25 +131,28 @@ class RustBuilder {
   Future<String> build() async {
     final extraArgs = _buildOptions?.flags ?? [];
     final manifestPath = path.join(environment.manifestDir, 'Cargo.toml');
-    runCommand('rustup', [
-      'run',
-      _toolchain,
-      'cargo',
-      environment.glibcVersion != null ? 'zigbuild' : 'build',
-      ...extraArgs,
-      '--manifest-path',
-      manifestPath,
-      '-p',
-      environment.crateInfo.packageName,
-      if (!environment.configuration.isDebug) '--release',
-      '--target',
-      target.rust +
-          (environment.glibcVersion != null
-              ? '.${environment.glibcVersion!}'
-              : ""),
-      '--target-dir',
-      environment.targetTempDir,
-    ], environment: await _buildEnvironment());
+    runCommand(
+        'rustup',
+        [
+          'run',
+          _toolchain,
+          'cargo',
+          environment.glibcVersion != null ? 'zigbuild' : 'build',
+          ...extraArgs,
+          '--manifest-path',
+          manifestPath,
+          '-p',
+          environment.crateInfo.packageName,
+          if (!environment.configuration.isDebug) '--release',
+          '--target',
+          target.rust +
+              (environment.glibcVersion != null
+                  ? '.${environment.glibcVersion!}'
+                  : ""),
+          '--target-dir',
+          environment.targetTempDir,
+        ],
+        environment: await _buildEnvironment());
     return path.join(
       environment.targetTempDir,
       target.rust,

--- a/build_tool/lib/src/crate_hash.dart
+++ b/build_tool/lib/src/crate_hash.dart
@@ -21,10 +21,7 @@ class CrateHash {
     )._compute();
   }
 
-  CrateHash._({
-    required this.manifestDir,
-    required this.tempStorage,
-  });
+  CrateHash._({required this.manifestDir, required this.tempStorage});
 
   String _compute() {
     final files = getFiles();
@@ -97,10 +94,11 @@ class CrateHash {
 
   List<File> getFiles() {
     final src = Directory(path.join(manifestDir, 'src'));
-    final files = src
-        .listSync(recursive: true, followLinks: false)
-        .whereType<File>()
-        .toList();
+    final files =
+        src
+            .listSync(recursive: true, followLinks: false)
+            .whereType<File>()
+            .toList();
     files.sortBy((element) => element.path);
     void addFile(String relative) {
       final file = File(path.join(manifestDir, relative));

--- a/build_tool/lib/src/crate_hash.dart
+++ b/build_tool/lib/src/crate_hash.dart
@@ -94,11 +94,10 @@ class CrateHash {
 
   List<File> getFiles() {
     final src = Directory(path.join(manifestDir, 'src'));
-    final files =
-        src
-            .listSync(recursive: true, followLinks: false)
-            .whereType<File>()
-            .toList();
+    final files = src
+        .listSync(recursive: true, followLinks: false)
+        .whereType<File>()
+        .toList();
     files.sortBy((element) => element.path);
     void addFile(String relative) {
       final file = File(path.join(manifestDir, relative));

--- a/build_tool/lib/src/logging.dart
+++ b/build_tool/lib/src/logging.dart
@@ -34,11 +34,7 @@ void initLogging() {
     final lines = rec.message.split('\n');
     for (final line in lines) {
       if (line.isNotEmpty || lines.length == 1 || line != lines.last) {
-        _log(LogRecord(
-          rec.level,
-          line,
-          rec.loggerName,
-        ));
+        _log(LogRecord(rec.level, line, rec.loggerName));
       }
     }
   });

--- a/build_tool/lib/src/options.dart
+++ b/build_tool/lib/src/options.dart
@@ -128,25 +128,24 @@ class PrecompiledBinaries {
 
   static PrecompiledBinaries parse(YamlNode node) {
     if (node case YamlMap(valueMap: Map<dynamic, YamlNode> map)) {
-      if (map case {
-        'url_prefix': YamlNode urlPrefixNode,
-        'public_key': YamlNode publicKeyNode,
-      }) {
+      if (map
+          case {
+            'url_prefix': YamlNode urlPrefixNode,
+            'public_key': YamlNode publicKeyNode,
+          }) {
         final urlPrefix = switch (urlPrefixNode) {
           YamlScalar(value: String urlPrefix) => urlPrefix,
-          _ =>
-            throw SourceSpanException(
+          _ => throw SourceSpanException(
               'Invalid URL prefix value.',
               urlPrefixNode.span,
             ),
         };
         final publicKey = switch (publicKeyNode) {
           YamlScalar(value: String publicKey) => _publicKeyFromHex(
-            publicKey,
-            publicKeyNode.span,
-          ),
-          _ =>
-            throw SourceSpanException(
+              publicKey,
+              publicKeyNode.span,
+            ),
+          _ => throw SourceSpanException(
               'Invalid public key value.',
               publicKeyNode.span,
             ),
@@ -177,10 +176,11 @@ class CargokitCrateOptions {
     PrecompiledBinaries? precompiledBinaries;
 
     for (final entry in node.nodes.entries) {
-      if (entry case MapEntry(
-        key: YamlScalar(value: 'cargo'),
-        value: YamlNode node,
-      )) {
+      if (entry
+          case MapEntry(
+            key: YamlScalar(value: 'cargo'),
+            value: YamlNode node,
+          )) {
         if (node is! YamlMap) {
           throw SourceSpanException('Cargo options must be a map', node.span);
         }
@@ -239,8 +239,8 @@ class CargokitUserOptions {
   });
 
   CargokitUserOptions._()
-    : usePrecompiledBinaries = defaultUsePrecompiledBinaries(),
-      verboseLogging = false;
+      : usePrecompiledBinaries = defaultUsePrecompiledBinaries(),
+        verboseLogging = false;
 
   static CargokitUserOptions parse(YamlNode node) {
     if (node is! YamlMap) {

--- a/build_tool/lib/src/options.dart
+++ b/build_tool/lib/src/options.dart
@@ -44,32 +44,27 @@ class SourceSpanException implements Exception {
   }
 }
 
-enum Toolchain {
-  stable,
-  beta,
-  nightly,
-}
+enum Toolchain { stable, beta, nightly }
 
 class CargoBuildOptions {
   final Toolchain toolchain;
   final List<String> flags;
 
-  CargoBuildOptions({
-    required this.toolchain,
-    required this.flags,
-  });
+  CargoBuildOptions({required this.toolchain, required this.flags});
 
   static Toolchain _toolchainFromNode(YamlNode node) {
     if (node case YamlScalar(value: String name)) {
-      final toolchain =
-          Toolchain.values.firstWhereOrNull((element) => element.name == name);
+      final toolchain = Toolchain.values.firstWhereOrNull(
+        (element) => element.name == name,
+      );
       if (toolchain != null) {
         return toolchain;
       }
     }
     throw SourceSpanException(
-        'Unknown toolchain. Must be one of ${Toolchain.values.map((e) => e.name)}.',
-        node.span);
+      'Unknown toolchain. Must be one of ${Toolchain.values.map((e) => e.name)}.',
+      node.span,
+    );
   }
 
   static CargoBuildOptions parse(YamlNode node) {
@@ -94,11 +89,14 @@ class CargoBuildOptions {
           }
         }
         throw SourceSpanException(
-            'Extra flags must be a list of strings', value.span);
+          'Extra flags must be a list of strings',
+          value.span,
+        );
       } else {
         throw SourceSpanException(
-            'Unknown cargo option type. Must be "toolchain" or "extra_flags".',
-            key.span);
+          'Unknown cargo option type. Must be "toolchain" or "extra_flags".',
+          key.span,
+        );
       }
     }
     return CargoBuildOptions(toolchain: toolchain, flags: flags);
@@ -115,57 +113,58 @@ class PrecompiledBinaries {
   final String uriPrefix;
   final PublicKey publicKey;
 
-  PrecompiledBinaries({
-    required this.uriPrefix,
-    required this.publicKey,
-  });
+  PrecompiledBinaries({required this.uriPrefix, required this.publicKey});
 
   static PublicKey _publicKeyFromHex(String key, SourceSpan? span) {
     final bytes = HEX.decode(key);
     if (bytes.length != 32) {
       throw SourceSpanException(
-          'Invalid public key. Must be 32 bytes long.', span);
+        'Invalid public key. Must be 32 bytes long.',
+        span,
+      );
     }
     return PublicKey(bytes);
   }
 
   static PrecompiledBinaries parse(YamlNode node) {
     if (node case YamlMap(valueMap: Map<dynamic, YamlNode> map)) {
-      if (map
-          case {
-            'url_prefix': YamlNode urlPrefixNode,
-            'public_key': YamlNode publicKeyNode,
-          }) {
+      if (map case {
+        'url_prefix': YamlNode urlPrefixNode,
+        'public_key': YamlNode publicKeyNode,
+      }) {
         final urlPrefix = switch (urlPrefixNode) {
           YamlScalar(value: String urlPrefix) => urlPrefix,
-          _ => throw SourceSpanException(
-              'Invalid URL prefix value.', urlPrefixNode.span),
+          _ =>
+            throw SourceSpanException(
+              'Invalid URL prefix value.',
+              urlPrefixNode.span,
+            ),
         };
         final publicKey = switch (publicKeyNode) {
-          YamlScalar(value: String publicKey) =>
-            _publicKeyFromHex(publicKey, publicKeyNode.span),
-          _ => throw SourceSpanException(
-              'Invalid public key value.', publicKeyNode.span),
+          YamlScalar(value: String publicKey) => _publicKeyFromHex(
+            publicKey,
+            publicKeyNode.span,
+          ),
+          _ =>
+            throw SourceSpanException(
+              'Invalid public key value.',
+              publicKeyNode.span,
+            ),
         };
-        return PrecompiledBinaries(
-          uriPrefix: urlPrefix,
-          publicKey: publicKey,
-        );
+        return PrecompiledBinaries(uriPrefix: urlPrefix, publicKey: publicKey);
       }
     }
     throw SourceSpanException(
-        'Invalid precompiled binaries value. '
-        'Expected Map with "url_prefix" and "public_key".',
-        node.span);
+      'Invalid precompiled binaries value. '
+      'Expected Map with "url_prefix" and "public_key".',
+      node.span,
+    );
   }
 }
 
 /// Cargokit options specified for Rust crate.
 class CargokitCrateOptions {
-  CargokitCrateOptions({
-    this.cargo = const {},
-    this.precompiledBinaries,
-  });
+  CargokitCrateOptions({this.cargo = const {}, this.precompiledBinaries});
 
   final Map<BuildConfiguration, CargoBuildOptions> cargo;
   final PrecompiledBinaries? precompiledBinaries;
@@ -178,33 +177,35 @@ class CargokitCrateOptions {
     PrecompiledBinaries? precompiledBinaries;
 
     for (final entry in node.nodes.entries) {
-      if (entry
-          case MapEntry(
-            key: YamlScalar(value: 'cargo'),
-            value: YamlNode node,
-          )) {
+      if (entry case MapEntry(
+        key: YamlScalar(value: 'cargo'),
+        value: YamlNode node,
+      )) {
         if (node is! YamlMap) {
           throw SourceSpanException('Cargo options must be a map', node.span);
         }
         for (final MapEntry(:YamlNode key, :value) in node.nodes.entries) {
           if (key case YamlScalar(value: String name)) {
-            final configuration = BuildConfiguration.values
-                .firstWhereOrNull((element) => element.name == name);
+            final configuration = BuildConfiguration.values.firstWhereOrNull(
+              (element) => element.name == name,
+            );
             if (configuration != null) {
               options[configuration] = CargoBuildOptions.parse(value);
               continue;
             }
           }
           throw SourceSpanException(
-              'Unknown build configuration. Must be one of ${BuildConfiguration.values.map((e) => e.name)}.',
-              key.span);
+            'Unknown build configuration. Must be one of ${BuildConfiguration.values.map((e) => e.name)}.',
+            key.span,
+          );
         }
       } else if (entry.key case YamlScalar(value: 'precompiled_binaries')) {
         precompiledBinaries = PrecompiledBinaries.parse(entry.value);
       } else {
         throw SourceSpanException(
-            'Unknown cargokit option type. Must be "cargo" or "precompiled_binaries".',
-            entry.key.span);
+          'Unknown cargokit option type. Must be "cargo" or "precompiled_binaries".',
+          entry.key.span,
+        );
       }
     }
     return CargokitCrateOptions(
@@ -213,9 +214,7 @@ class CargokitCrateOptions {
     );
   }
 
-  static CargokitCrateOptions load({
-    required String manifestDir,
-  }) {
+  static CargokitCrateOptions load({required String manifestDir}) {
     final uri = Uri.file(path.join(manifestDir, "cargokit.yaml"));
     final file = File.fromUri(uri);
     if (file.existsSync()) {
@@ -240,8 +239,8 @@ class CargokitUserOptions {
   });
 
   CargokitUserOptions._()
-      : usePrecompiledBinaries = defaultUsePrecompiledBinaries(),
-        verboseLogging = false;
+    : usePrecompiledBinaries = defaultUsePrecompiledBinaries(),
+      verboseLogging = false;
 
   static CargokitUserOptions parse(YamlNode node) {
     if (node is! YamlMap) {
@@ -257,20 +256,23 @@ class CargokitUserOptions {
           continue;
         }
         throw SourceSpanException(
-            'Invalid value for "use_precompiled_binaries". Must be a boolean.',
-            entry.value.span);
+          'Invalid value for "use_precompiled_binaries". Must be a boolean.',
+          entry.value.span,
+        );
       } else if (entry.key case YamlScalar(value: 'verbose_logging')) {
         if (entry.value case YamlScalar(value: bool value)) {
           verboseLogging = value;
           continue;
         }
         throw SourceSpanException(
-            'Invalid value for "verbose_logging". Must be a boolean.',
-            entry.value.span);
+          'Invalid value for "verbose_logging". Must be a boolean.',
+          entry.value.span,
+        );
       } else {
         throw SourceSpanException(
-            'Unknown cargokit option type. Must be "use_precompiled_binaries" or "verbose_logging".',
-            entry.key.span);
+          'Unknown cargokit option type. Must be "use_precompiled_binaries" or "verbose_logging".',
+          entry.key.span,
+        );
       }
     }
     return CargokitUserOptions(

--- a/build_tool/lib/src/precompile_binaries.dart
+++ b/build_tool/lib/src/precompile_binaries.dart
@@ -75,10 +75,9 @@ class PrecompileBinaries {
       hash: hash,
     );
 
-    final tempDir =
-        this.tempDir != null
-            ? Directory(this.tempDir!)
-            : Directory.systemTemp.createTempSync('precompiled_');
+    final tempDir = this.tempDir != null
+        ? Directory(this.tempDir!)
+        : Directory.systemTemp.createTempSync('precompiled_');
 
     tempDir.createSync(recursive: true);
 
@@ -195,8 +194,7 @@ class PrecompileBinaries {
           targetCommitish: null,
           isDraft: false,
           isPrerelease: false,
-          body:
-              'Precompiled binaries for crate $packageName, '
+          body: 'Precompiled binaries for crate $packageName, '
               'crate hash $hash.',
         ),
       );

--- a/build_tool/lib/src/rustup.dart
+++ b/build_tool/lib/src/rustup.dart
@@ -55,12 +55,11 @@ class Rustup {
 
   Rustup() : _installedToolchains = _getInstalledToolchains();
 
-  List<String>? _installedTargets(String toolchain) =>
-      _installedToolchains
-          .firstWhereOrNull(
-            (e) => e.name == toolchain || e.name.startsWith('$toolchain-'),
-          )
-          ?.targets;
+  List<String>? _installedTargets(String toolchain) => _installedToolchains
+      .firstWhereOrNull(
+        (e) => e.name == toolchain || e.name.startsWith('$toolchain-'),
+      )
+      ?.targets;
 
   static List<_Toolchain> _getInstalledToolchains() {
     String extractToolchainName(String line) {
@@ -122,10 +121,9 @@ class Rustup {
   static String? executablePath() {
     final envPath = Platform.environment['PATH'];
     final envPathSeparator = Platform.isWindows ? ';' : ':';
-    final home =
-        Platform.isWindows
-            ? Platform.environment['USERPROFILE']
-            : Platform.environment['HOME'];
+    final home = Platform.isWindows
+        ? Platform.environment['USERPROFILE']
+        : Platform.environment['HOME'];
     final paths = [
       if (home != null) path.join(home, '.cargo', 'bin'),
       if (envPath != null) ...envPath.split(envPathSeparator),

--- a/build_tool/lib/src/target.dart
+++ b/build_tool/lib/src/target.dart
@@ -109,16 +109,14 @@ class Target {
         return [Target.forRustTriple('x86_64-unknown-linux-gnu')!];
       }
     }
-    return all
-        .where((target) {
-          if (Platform.isWindows) {
-            return target.rust.contains('-windows-');
-          } else if (Platform.isMacOS) {
-            return target.darwinPlatform != null;
-          }
-          return false;
-        })
-        .toList(growable: false);
+    return all.where((target) {
+      if (Platform.isWindows) {
+        return target.rust.contains('-windows-');
+      } else if (Platform.isMacOS) {
+        return target.darwinPlatform != null;
+      }
+      return false;
+    }).toList(growable: false);
   }
 
   @override

--- a/build_tool/lib/src/target.dart
+++ b/build_tool/lib/src/target.dart
@@ -39,18 +39,10 @@ class Target {
       android: 'x86_64',
       androidMinSdkVersion: 21,
     ),
-    Target(
-      rust: 'x86_64-pc-windows-msvc',
-      flutter: 'windows-x64',
-    ),
-    Target(
-      rust: 'x86_64-unknown-linux-gnu',
-      flutter: 'linux-x64',
-    ),
-    Target(
-      rust: 'aarch64-unknown-linux-gnu',
-      flutter: 'linux-arm64',
-    ),
+    Target(rust: 'x86_64-pc-windows-msvc', flutter: 'windows-x64'),
+    Target(rust: 'x86_64-unknown-linux-gnu', flutter: 'linux-x64'),
+    Target(rust: 'aarch64-unknown-linux-gnu', flutter: 'linux-arm64'),
+    Target(rust: 'riscv64gc-unknown-linux-gnu', flutter: 'linux-riscv64'),
     Target(
       rust: 'x86_64-apple-darwin',
       darwinPlatform: 'macosx',
@@ -86,9 +78,11 @@ class Target {
     required String platformName,
     required String darwinAarch,
   }) {
-    return all.firstWhereOrNull((element) => //
-        element.darwinPlatform == platformName &&
-        element.darwinArch == darwinAarch);
+    return all.firstWhereOrNull(
+      (element) => //
+          element.darwinPlatform == platformName &&
+          element.darwinArch == darwinAarch,
+    );
   }
 
   static Target? forRustTriple(String triple) {
@@ -106,21 +100,25 @@ class Target {
     if (Platform.isLinux) {
       // Right now we don't support cross-compiling on Linux. So we just return
       // the host target.
-      final arch = runCommand('arch', []).stdout as String;
-      if (arch.trim() == 'aarch64') {
+      final arch = (runCommand('arch', []).stdout as String).trim();
+      if (arch == 'aarch64') {
         return [Target.forRustTriple('aarch64-unknown-linux-gnu')!];
+      } else if (arch == 'riscv64') {
+        return [Target.forRustTriple('riscv64gc-unknown-linux-gnu')!];
       } else {
         return [Target.forRustTriple('x86_64-unknown-linux-gnu')!];
       }
     }
-    return all.where((target) {
-      if (Platform.isWindows) {
-        return target.rust.contains('-windows-');
-      } else if (Platform.isMacOS) {
-        return target.darwinPlatform != null;
-      }
-      return false;
-    }).toList(growable: false);
+    return all
+        .where((target) {
+          if (Platform.isWindows) {
+            return target.rust.contains('-windows-');
+          } else if (Platform.isMacOS) {
+            return target.darwinPlatform != null;
+          }
+          return false;
+        })
+        .toList(growable: false);
   }
 
   @override

--- a/build_tool/lib/src/target.dart
+++ b/build_tool/lib/src/target.dart
@@ -79,7 +79,7 @@ class Target {
     required String darwinAarch,
   }) {
     return all.firstWhereOrNull(
-      (element) => //
+      (element) =>
           element.darwinPlatform == platformName &&
           element.darwinArch == darwinAarch,
     );

--- a/build_tool/lib/src/util.dart
+++ b/build_tool/lib/src/util.dart
@@ -86,16 +86,18 @@ ProcessResult runCommand(
   Encoding? stderrEncoding = systemEncoding,
 }) {
   if (testRunCommandOverride != null) {
-    final result = testRunCommandOverride!(TestRunCommandArgs(
-      executable: executable,
-      arguments: arguments,
-      workingDirectory: workingDirectory,
-      environment: environment,
-      includeParentEnvironment: includeParentEnvironment,
-      runInShell: runInShell,
-      stdoutEncoding: stdoutEncoding,
-      stderrEncoding: stderrEncoding,
-    ));
+    final result = testRunCommandOverride!(
+      TestRunCommandArgs(
+        executable: executable,
+        arguments: arguments,
+        workingDirectory: workingDirectory,
+        environment: environment,
+        includeParentEnvironment: includeParentEnvironment,
+        runInShell: runInShell,
+        stdoutEncoding: stdoutEncoding,
+        stderrEncoding: stderrEncoding,
+      ),
+    );
     return ProcessResult(
       result.pid,
       result.exitCode,

--- a/build_tool/lib/src/verify_binaries.dart
+++ b/build_tool/lib/src/verify_binaries.dart
@@ -11,9 +11,7 @@ import 'precompile_binaries.dart';
 import 'target.dart';
 
 class VerifyBinaries {
-  VerifyBinaries({
-    required this.manifestDir,
-  });
+  VerifyBinaries({required this.manifestDir});
 
   final String manifestDir;
 
@@ -45,12 +43,15 @@ class VerifyBinaries {
 
         for (final artifact in artifacts) {
           final fileName = PrecompileBinaries.fileName(target, artifact);
-          final signatureFileName =
-              PrecompileBinaries.signatureFileName(target, artifact);
+          final signatureFileName = PrecompileBinaries.signatureFileName(
+            target,
+            artifact,
+          );
 
           final url = Uri.parse('$prefix$crateHash/$fileName');
-          final signatureUrl =
-              Uri.parse('$prefix$crateHash/$signatureFileName');
+          final signatureUrl = Uri.parse(
+            '$prefix$crateHash/$signatureFileName',
+          );
 
           final signature = await get(signatureUrl);
           if (signature.statusCode != 200) {
@@ -65,8 +66,11 @@ class VerifyBinaries {
             break;
           }
 
-          if (!verify(precompiledBinaries.publicKey, asset.bodyBytes,
-              signature.bodyBytes)) {
+          if (!verify(
+            precompiledBinaries.publicKey,
+            asset.bodyBytes,
+            signature.bodyBytes,
+          )) {
             stdout.writeln('INVALID SIGNATURE');
             ok = false;
           }

--- a/build_tool/test/options_test.dart
+++ b/build_tool/test/options_test.dart
@@ -26,7 +26,8 @@ public_key: a4c3433798eb2c36edf2b94dbb4dd899d57496ca373a8982d8a792410b7f6445
 """;
     final precompiledBinaries = PrecompiledBinaries.parse(loadYamlNode(yaml));
     final key = HEX.decode(
-        'a4c3433798eb2c36edf2b94dbb4dd899d57496ca373a8982d8a792410b7f6445');
+      'a4c3433798eb2c36edf2b94dbb4dd899d57496ca373a8982d8a792410b7f6445',
+    );
     expect(precompiledBinaries.uriPrefix, 'https://url-prefix');
     expect(precompiledBinaries.publicKey.bytes, key);
   });
@@ -51,7 +52,8 @@ precompiled_binaries:
     final options = CargokitCrateOptions.parse(loadYamlNode(yaml));
     expect(options.precompiledBinaries?.uriPrefix, 'https://url-prefix');
     final key = HEX.decode(
-        'a4c3433798eb2c36edf2b94dbb4dd899d57496ca373a8982d8a792410b7f6445');
+      'a4c3433798eb2c36edf2b94dbb4dd899d57496ca373a8982d8a792410b7f6445',
+    );
     expect(options.precompiledBinaries?.publicKey.bytes, key);
 
     final debugOptions = options.cargo[BuildConfiguration.debug]!;

--- a/build_tool/test/rustup_test.dart
+++ b/build_tool/test/rustup_test.dart
@@ -19,7 +19,8 @@ void main() {
         case ['target', 'list', '--toolchain', 'stable', '--installed']:
           didListTargets = true;
           return TestRunCommandResult(
-              stdout: 'x86_64-unknown-linux-gnu\nx86_64-apple-darwin\n');
+            stdout: 'x86_64-unknown-linux-gnu\nx86_64-apple-darwin\n',
+          );
         default:
           throw Exception('Unexpected call: ${args.arguments}');
       }
@@ -43,9 +44,11 @@ void main() {
       switch (args.arguments) {
         case ['toolchain', 'list']:
           return TestRunCommandResult(
-              stdout: 'stable-aarch64-apple-darwin (default)\n'
-                  'nightly-aarch64-apple-darwin\n'
-                  'esp\n');
+            stdout:
+                'stable-aarch64-apple-darwin (default)\n'
+                'nightly-aarch64-apple-darwin\n'
+                'esp\n',
+          );
         case ['target', 'list', '--toolchain', String toolchain, '--installed']:
           targetsQueried.add(toolchain);
           return TestRunCommandResult(stdout: '$toolchain:target\n');
@@ -58,9 +61,11 @@ void main() {
       'stable-aarch64-apple-darwin',
       'nightly-aarch64-apple-darwin',
     ]);
-    expect(rustup.installedTargets('stable'),
-        ['stable-aarch64-apple-darwin:target']);
-    expect(rustup.installedTargets('nightly'),
-        ['nightly-aarch64-apple-darwin:target']);
+    expect(rustup.installedTargets('stable'), [
+      'stable-aarch64-apple-darwin:target',
+    ]);
+    expect(rustup.installedTargets('nightly'), [
+      'nightly-aarch64-apple-darwin:target',
+    ]);
   });
 }

--- a/build_tool/test/rustup_test.dart
+++ b/build_tool/test/rustup_test.dart
@@ -44,8 +44,7 @@ void main() {
       switch (args.arguments) {
         case ['toolchain', 'list']:
           return TestRunCommandResult(
-            stdout:
-                'stable-aarch64-apple-darwin (default)\n'
+            stdout: 'stable-aarch64-apple-darwin (default)\n'
                 'nightly-aarch64-apple-darwin\n'
                 'esp\n',
           );


### PR DESCRIPTION
- Adds a `glibc-version` option to `build_tool` which uses zigbuild to override the glibc version for precompiled binaries
- Adds a Rust target for riscv64 and adds detection of this architecture to `build_tool`
- Related: the example plugin workflow does not currently pass due to Flutter Android changes, [this PR](https://github.com/irondash/hello_rust_ffi_plugin/pull/1) should be merged to resolve the issue