### PR TITLE
Fix symlink resolution on windows for mapped Drives

### DIFF
--- a/cmake/resolve_symlinks.ps1
+++ b/cmake/resolve_symlinks.ps1
@@ -14,14 +14,21 @@ function Resolve-Symlinks {
         if ($realPath -and !$realPath.EndsWith($separator)) {
             $realPath += $separator
         }
-        $realPath += $part
+
+        $realPath += $part.Replace('\', '/')
+
+        # The slash is important when using Get-Item on Drive letters in pwsh.
+        if (-not($realPath.Contains($separator)) -and $realPath.EndsWith(':')) {
+            $realPath += '/'
+        }
+
         $item = Get-Item $realPath
-        if ($item.Target) {
-            $realPath = $item.Target.Replace('\', '/')
+        if ($item.LinkTarget) {
+            $realPath = $item.LinkTarget.Replace('\', '/')
         }
     }
     $realPath
 }
 
-$path=Resolve-Symlinks -Path $args[0]
+$path = Resolve-Symlinks -Path $args[0]
 Write-Host $path


### PR DESCRIPTION
Fixes the resolution of symbolic links on windows when using mapped Drives.

## Background
When the code (and the PubCache) are located on a [`subst`](https://learn.microsoft.com/de-de/windows-server/administration/windows-commands/subst)ed drive on windows, the script for resolving the symlinks fails.

This is because `(Get-Item Z:\).Target` resolves to the actual path to which the drive is mounted (at least in Windows PowerShell 5.x, in PowerShell 6+ this behavior different). However because the drive letter is never changed at the start of the path, the resolved path will now become invalid.

## Solution
Using [`LinkTarget`](https://learn.microsoft.com/en-us/dotnet/api/system.io.filesysteminfo.linktarget?view=net-9.0#system-io-filesysteminfo-linktarget) is the better approach as it will only be non-null when an actual symlink is encountered.  
As far as I can tell from my research `LinkTarget` should be supported on older PowerShell Versions (Windows PowerShell 5.1) as well.

Note: The other changes apart from switching `Target` to `LinkTarget` are not strictly necessary for fixing the problem, but I hope they are a welcome addition nevertheless.

Please let me know what you think.