### PR TITLE
Feature: support for local precompiled binaries

### DIFF
--- a/build_tool/lib/src/artifacts_provider.dart
+++ b/build_tool/lib/src/artifacts_provider.dart
@@ -297,7 +297,7 @@ class ArtifactProvider {
     required String finalPath,
     required String sdkDirectory,
   }) async {
-    final sdkPath = '$sdkDirectory/../binary/$fileName';
+    final sdkPath = '$sdkDirectory/binary/$fileName';
     final binaryFile = File(sdkPath);
     if (!binaryFile.existsSync()) {
       throw Exception('Missing artifact: ${binaryFile.path}');

--- a/build_tool/lib/src/build_tool.dart
+++ b/build_tool/lib/src/build_tool.dart
@@ -13,6 +13,7 @@ import 'build_pod.dart';
 import 'logging.dart';
 import 'options.dart';
 import 'precompile_binaries.dart';
+import 'precompile_local_binaries.dart';
 import 'target.dart';
 import 'util.dart';
 import 'verify_binaries.dart';
@@ -91,6 +92,94 @@ class GenKeyCommand extends Command {
     final public = HEX.encode(kp.publicKey.bytes);
     print("Private Key: $private");
     print("Public Key: $public");
+  }
+}
+
+class PrecompileLocalBinariesCommand extends Command {
+  PrecompileLocalBinariesCommand() {
+    argParser
+      ..addOption(
+        'manifest-dir',
+        mandatory: true,
+        help: 'Directory containing Cargo.toml',
+      )
+      ..addMultiOption(
+        'target',
+        help: 'Rust target triple of artifact to build.\n'
+            'Can be specified multiple times or omitted in which case\n'
+            'all targets for current platform will be built.',
+      )
+      ..addOption(
+        'android-sdk-location',
+        help: 'Location of Android SDK (if available)',
+      )
+      ..addOption(
+        'android-ndk-version',
+        help: 'Android NDK version (if available)',
+      )
+      ..addOption(
+        'android-min-sdk-version',
+        help: 'Android minimum rquired version (if available)',
+      )
+      ..addOption(
+        'temp-dir',
+        help: 'Directory to store temporary build artifacts',
+      )
+      ..addFlag(
+        "verbose",
+        abbr: "v",
+        defaultsTo: false,
+        help: "Enable verbose logging",
+      );
+  }
+
+  @override
+  final name = 'precompile-local-binaries';
+
+  @override
+  final description = 'Prebuild and create local binaries\n';
+
+  @override
+  Future<void> run() async {
+    final verbose = argResults!['verbose'] as bool;
+    if (verbose) {
+      enableVerboseLogging();
+    }
+
+    final manifestDir = argResults!['manifest-dir'] as String;
+    if (!Directory(manifestDir).existsSync()) {
+      throw ArgumentError('Manifest directory does not exist: $manifestDir');
+    }
+    String? androidMinSdkVersionString =
+        argResults!['android-min-sdk-version'] as String?;
+    int? androidMinSdkVersion;
+    if (androidMinSdkVersionString != null) {
+      androidMinSdkVersion = int.tryParse(androidMinSdkVersionString);
+      if (androidMinSdkVersion == null) {
+        throw ArgumentError(
+          'Invalid android-min-sdk-version: $androidMinSdkVersionString',
+        );
+      }
+    }
+    final targetStrigns = argResults!['target'] as List<String>;
+    final targets = targetStrigns.map((target) {
+      final res = Target.forRustTriple(target);
+      if (res == null) {
+        throw ArgumentError('Invalid target: $target');
+      }
+      return res;
+    }).toList(growable: false);
+
+    final precompileBinaries = PrecompileLocalBinaries(
+      manifestDir: manifestDir,
+      targets: targets,
+      androidSdkLocation: argResults!['android-sdk-location'] as String?,
+      androidNdkVersion: argResults!['android-ndk-version'] as String?,
+      androidMinSdkVersion: androidMinSdkVersion,
+      tempDir: argResults!['temp-dir'] as String?,
+    );
+
+    await precompileBinaries.run();
   }
 }
 
@@ -243,6 +332,7 @@ Future<void> runMain(List<String> args) async {
       ..addCommand(BuildCMakeCommand())
       ..addCommand(GenKeyCommand())
       ..addCommand(PrecompileBinariesCommand())
+      ..addCommand(PrecompileLocalBinariesCommand())
       ..addCommand(VerifyBinariesCommand());
 
     await runner.run(args);

--- a/build_tool/lib/src/options.dart
+++ b/build_tool/lib/src/options.dart
@@ -237,13 +237,13 @@ class CargokitUserOptions {
   CargokitUserOptions({
     required this.usePrecompiledBinaries,
     required this.verboseLogging,
-    this.useLocalPrecompiledBinaries = true,
+    required this.useLocalPrecompiledBinaries,
   });
 
   CargokitUserOptions._()
       : usePrecompiledBinaries = defaultUsePrecompiledBinaries(),
         verboseLogging = false,
-        useLocalPrecompiledBinaries = true;
+        useLocalPrecompiledBinaries = false;
 
   static CargokitUserOptions parse(YamlNode node) {
     if (node is! YamlMap) {
@@ -251,6 +251,7 @@ class CargokitUserOptions {
     }
     bool usePrecompiledBinaries = defaultUsePrecompiledBinaries();
     bool verboseLogging = false;
+    bool useLocalPrecompiledBinaries = false;
 
     for (final entry in node.nodes.entries) {
       if (entry.key case YamlScalar(value: 'use_precompiled_binaries')) {
@@ -269,15 +270,25 @@ class CargokitUserOptions {
         throw SourceSpanException(
             'Invalid value for "verbose_logging". Must be a boolean.',
             entry.value.span);
+      } else if (entry.key
+          case YamlScalar(value: 'use_local_precompiled_binaries')) {
+        if (entry.value case YamlScalar(value: bool value)) {
+          useLocalPrecompiledBinaries = value;
+          continue;
+        }
+        throw SourceSpanException(
+            'Invalid value for "use_local_precompiled_binaries". Must be a boolean.',
+            entry.value.span);
       } else {
         throw SourceSpanException(
-            'Unknown cargokit option type. Must be "use_precompiled_binaries" or "verbose_logging".',
+            'Unknown cargokit option type. Must be "use_precompiled_binaries" , "use_local_precompiled_binaries" or "verbose_logging".',
             entry.key.span);
       }
     }
     return CargokitUserOptions(
       usePrecompiledBinaries: usePrecompiledBinaries,
       verboseLogging: verboseLogging,
+      useLocalPrecompiledBinaries: useLocalPrecompiledBinaries,
     );
   }
 

--- a/build_tool/lib/src/options.dart
+++ b/build_tool/lib/src/options.dart
@@ -237,11 +237,13 @@ class CargokitUserOptions {
   CargokitUserOptions({
     required this.usePrecompiledBinaries,
     required this.verboseLogging,
+    this.useLocalPrecompiledBinaries = true,
   });
 
   CargokitUserOptions._()
       : usePrecompiledBinaries = defaultUsePrecompiledBinaries(),
-        verboseLogging = false;
+        verboseLogging = false,
+        useLocalPrecompiledBinaries = true;
 
   static CargokitUserOptions parse(YamlNode node) {
     if (node is! YamlMap) {
@@ -303,4 +305,5 @@ class CargokitUserOptions {
 
   final bool usePrecompiledBinaries;
   final bool verboseLogging;
+  final bool useLocalPrecompiledBinaries;
 }

--- a/build_tool/lib/src/precompile_local_binaries.dart
+++ b/build_tool/lib/src/precompile_local_binaries.dart
@@ -1,6 +1,3 @@
-/// This is copied from Cargokit (which is the official way to use it currently)
-/// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
-
 import 'dart:io';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;

--- a/build_tool/lib/src/precompile_local_binaries.dart
+++ b/build_tool/lib/src/precompile_local_binaries.dart
@@ -97,7 +97,7 @@ class PrecompileLocalBinaries {
           throw Exception('Missing artifact: ${file.path}');
         }
 
-        String destinationPath = "../../binary/$target/$name";
+        String destinationPath = "../binary/$target/$name";
         File destinationFile = File(destinationPath);
         destinationFile.parent.createSync(recursive: true);
         file.copySync(destinationPath);

--- a/build_tool/lib/src/precompile_local_binaries.dart
+++ b/build_tool/lib/src/precompile_local_binaries.dart
@@ -1,0 +1,110 @@
+/// This is copied from Cargokit (which is the official way to use it currently)
+/// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
+
+import 'dart:io';
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as path;
+
+import 'artifacts_provider.dart';
+import 'builder.dart';
+import 'cargo.dart';
+import 'options.dart';
+import 'rustup.dart';
+import 'target.dart';
+
+final _log = Logger('precompile_local_binaries');
+
+class PrecompileLocalBinaries {
+  PrecompileLocalBinaries({
+    required this.manifestDir,
+    required this.targets,
+    this.androidSdkLocation,
+    this.androidNdkVersion,
+    this.androidMinSdkVersion,
+    this.tempDir,
+  });
+
+  final String manifestDir;
+  final List<Target> targets;
+  final String? androidSdkLocation;
+  final String? androidNdkVersion;
+  final int? androidMinSdkVersion;
+  final String? tempDir;
+
+  static String fileName(
+    Target target,
+    String name,
+  ) {
+    return '${target.rust}_$name';
+  }
+
+  static String signatureFileName(
+    Target target,
+    String name,
+  ) {
+    return '${target.rust}_$name.sig';
+  }
+
+  Future<void> run() async {
+    final crateInfo = CrateInfo.load(manifestDir);
+
+    final targets = List.of(this.targets);
+    if (targets.isEmpty) {
+      targets.addAll([
+        ...Target.buildableTargets(),
+        if (androidSdkLocation != null) ...Target.androidTargets(),
+      ]);
+    }
+
+    _log.info('Precompiling binaries for $targets');
+
+    final tempDir = this.tempDir != null
+        ? Directory(this.tempDir!)
+        : Directory.systemTemp.createTempSync('precompiled_');
+
+    tempDir.createSync(recursive: true);
+
+    final crateOptions = CargokitCrateOptions.load(manifestDir: manifestDir);
+
+    final buildEnvironment = BuildEnvironment(
+      configuration: BuildConfiguration.release,
+      crateOptions: crateOptions,
+      targetTempDir: tempDir.path,
+      manifestDir: manifestDir,
+      crateInfo: crateInfo,
+      isAndroid: androidSdkLocation != null,
+      androidSdkPath: androidSdkLocation,
+      androidNdkVersion: androidNdkVersion,
+      androidMinSdkVersion: androidMinSdkVersion,
+    );
+
+    final rustup = Rustup();
+
+    for (final target in targets) {
+      final artifactNames = getArtifactNames(
+          target: target, libraryName: crateInfo.packageName, remote: true);
+
+      _log.info('Building for $target');
+
+      final builder =
+          RustBuilder(target: target, environment: buildEnvironment);
+      builder.prepare(rustup);
+      final res = await builder.build();
+
+      for (final name in artifactNames) {
+        final file = File(path.join(res, name));
+        if (!file.existsSync()) {
+          throw Exception('Missing artifact: ${file.path}');
+        }
+
+        String destinationPath = "../../binary/$target/$name";
+        File destinationFile = File(destinationPath);
+        destinationFile.parent.createSync(recursive: true);
+        file.copySync(destinationPath);
+      }
+    }
+
+    _log.info('Cleaning up');
+    tempDir.deleteSync(recursive: true);
+  }
+}

--- a/run_build_tool.sh
+++ b/run_build_tool.sh
@@ -80,6 +80,11 @@ if [ ! -f "$PACKAGE_HASH_FILE" ]; then
     echo "$PACKAGE_HASH" > "$PACKAGE_HASH_FILE"
 fi
 
+# Rebuild the tool if it was deleted by Android Studio
+if [ ! -f "bin/build_tool_runner.dill" ]; then
+  "$DART" compile kernel bin/build_tool_runner.dart
+fi
+
 set +e
 
 "$DART" bin/build_tool_runner.dill "$@"

--- a/run_build_tool.sh
+++ b/run_build_tool.sh
@@ -11,6 +11,9 @@ cd "$CARGOKIT_TOOL_TEMP_DIR"
 # Write a very simple bin package in temp folder that depends on build_tool package
 # from Cargokit. This is done to ensure that we don't pollute Cargokit folder
 # with .dart_tool contents.
+cat << EOF > "directory.txt"
+$BASEDIR
+EOF
 
 BUILD_TOOL_PKG_DIR="$BASEDIR/build_tool"
 
@@ -75,11 +78,6 @@ if [ ! -f "$PACKAGE_HASH_FILE" ]; then
     "$DART" pub get --no-precompile
     "$DART" compile kernel bin/build_tool_runner.dart
     echo "$PACKAGE_HASH" > "$PACKAGE_HASH_FILE"
-fi
-
-# Rebuild the tool if it was deleted by Android Studio
-if [ ! -f "bin/build_tool_runner.dill" ]; then
-  "$DART" compile kernel bin/build_tool_runner.dart
 fi
 
 set +e


### PR DESCRIPTION
Enable the generation and integration of precompiled binaries for specific targets and save it locally in binary folder. This feature allows binaries to be built once for supported platforms and reused when using with flutter rust bridge, eliminating the need for consumers to compile source code locally.

## Steps to use it

### 1. Create local precompiled binaries using command `precompile-local-binaries`

example command, change the values for your use.
```
flutter pub run bin/build_tool.dart precompile-local-binaries -v --manifest-dir ../../rust --android-sdk-location=/Users/asdf/Library/Android/sdk --android-ndk-version=28.0.12674087 --android-min-sdk-version=23 --temp-dir tempDir
```

### 2. Update `cargokit_options.yaml`
```
use_local_precompiled_binaries: true
use_precompiled_binaries: true
```

### 3. Use the package
When you share the flutter package, the developer will installed the package and when they try to run app, flutter_rust_bridge will use the precompiled binaries.