### PR TITLE
feat: add target for windows arm builds

### DIFF
--- a/build_tool/lib/src/target.dart
+++ b/build_tool/lib/src/target.dart
@@ -44,6 +44,10 @@ class Target {
       flutter: 'windows-x64',
     ),
     Target(
+      rust: 'aarch64-pc-windows-msvc',
+      flutter: 'windows-arm64',
+    ),
+    Target(
       rust: 'x86_64-unknown-linux-gnu',
       flutter: 'linux-x64',
     ),


### PR DESCRIPTION
Currently there is no target for windows arm builds. This adds one.