### PR TITLE
Fallback to the old style of Gradle plugin flow when the new style failed

### DIFF
--- a/gradle/plugin.gradle
+++ b/gradle/plugin.gradle
@@ -129,7 +129,12 @@ class CargoKitPlugin implements Plugin<Project> {
             def jniLibs = project.android.sourceSets.maybeCreate(buildType).jniLibs;
             jniLibs.srcDir(new File(cargoOutputDir))
 
-            def platforms = com.flutter.gradle.FlutterPluginUtils.getTargetPlatforms(project).collect()
+            def List<String> platforms
+            try {
+                platforms = com.flutter.gradle.FlutterPluginUtils.getTargetPlatforms(project).collect()
+            } catch (Exception ignored) {
+                platforms = plugin.getTargetPlatforms().collect()
+            }
 
             // Same thing addFlutterDependencies does in flutter.gradle
             if (buildType == "debug") {

--- a/gradle/plugin.gradle
+++ b/gradle/plugin.gradle
@@ -92,7 +92,7 @@ class CargoKitPlugin implements Plugin<Project> {
    private Plugin _findFlutterPlugin(Map projects) {
         for (project in projects) {
             for (plugin in project.value.getPlugins()) {
-                if (plugin.class.name == "com.flutter.gradle.FlutterPlugin") {
+                if (plugin.class.name == "com.flutter.gradle.FlutterPlugin" || plugin.class.name == "FlutterPlugin") {
                     return plugin;
                 }
             }


### PR DESCRIPTION
It provides backward compatibility to enable compilation on old Flutter versions (from the `flutter_rust_bridge` perspective, cc @fzyzcjy).