### PR TITLE
Add default BINDGEN_EXTRA_CLANG_ARGS for `AndroidEnvironment`

### DIFF
--- a/build_tool/lib/src/android_environment.dart
+++ b/build_tool/lib/src/android_environment.dart
@@ -147,6 +147,19 @@ class AndroidEnvironment {
     final toolTempDir =
         Platform.environment['CARGOKIT_TOOL_TEMP_DIR'] ?? targetTempDir;
 
+    final sysroot = path.join(
+      ndkPath,
+      'toolchains',
+      'llvm',
+      'prebuilt',
+      hostArch,
+      'sysroot',
+    );
+
+    final bindgenKey = "BINDGEN_EXTRA_CLANG_ARGS_${target.rust}";
+    final bindgenValue =
+        "--sysroot=$sysroot -I${path.join(sysroot, 'usr', 'include', target.rust)}";
+
     return {
       arKey: arValue,
       ccKey: ccValue,
@@ -156,6 +169,7 @@ class AndroidEnvironment {
       ranlibKey: ranlibValue,
       rustFlagsKey: rustFlagsValue,
       linkerKey: selfPath,
+      bindgenKey: bindgenValue,
       // Recognized by main() so we know when we're acting as a wrapper
       '_CARGOKIT_NDK_LINK_TARGET': targetArg,
       '_CARGOKIT_NDK_LINK_CLANG': ccValue,


### PR DESCRIPTION
## 📝 Description
Add default `BINDGEN_EXTRA_CLANG_ARGS` environment variable configuration for Android NDK builds to ensure bindgen correctly generates C/C++ bindings for the Android platform.

## 🔧 Changes
- Added default `BINDGEN_EXTRA_CLANG_ARGS` configuration
- Includes Android target architecture and sysroot path settings
- Ensures bindgen can locate Android NDK headers and libraries

## ✅ Problem Solved
- Fixes issue where bindgen couldn't properly parse Android-specific types and headers on Android platform
- Eliminates the tedious manual environment variable setup
- Improves consistency and reliability of Android builds