### PR TITLE
Remove hardcoded i686(x86) compilation for Android debug builds

### DIFF
--- a/build_tool/lib/src/target.dart
+++ b/build_tool/lib/src/target.dart
@@ -52,6 +52,14 @@ class Target {
       flutter: 'linux-arm64',
     ),
     Target(
+      rust: 'x86_64-unknown-linux-gnu',
+      flutter: 'elinux-x64',
+    ),
+    Target(
+      rust: 'aarch64-unknown-linux-gnu',
+      flutter: 'elinux-arm64',
+    ),
+    Target(
       rust: 'x86_64-apple-darwin',
       darwinPlatform: 'macosx',
       darwinArch: 'x86_64',

--- a/build_tool/lib/src/target.dart
+++ b/build_tool/lib/src/target.dart
@@ -57,14 +57,6 @@ class Target {
     ),
     Target(rust: 'riscv64gc-unknown-linux-gnu', flutter: 'linux-riscv64'),
     Target(
-      rust: 'x86_64-unknown-linux-gnu',
-      flutter: 'elinux-x64',
-    ),
-    Target(
-      rust: 'aarch64-unknown-linux-gnu',
-      flutter: 'elinux-arm64',
-    ),
-    Target(
       rust: 'x86_64-apple-darwin',
       darwinPlatform: 'macosx',
       darwinArch: 'x86_64',

--- a/gradle/plugin.gradle
+++ b/gradle/plugin.gradle
@@ -133,7 +133,6 @@ class CargoKitPlugin implements Plugin<Project> {
 
             // Same thing addFlutterDependencies does in flutter.gradle
             if (buildType == "debug") {
-                platforms.add("android-x86")
                 platforms.add("android-x64")
             }
 


### PR DESCRIPTION
# Summary
This PR removes the hardcoded logic that forces compilation for the i686(x86) platform in Android debug builds.

# Background
The current implementation hardcodes i686(x86) platform compilation for Android debug builds, which is no longer necessary and causes significant issues since:

* Flutter framework has officially dropped support for the x86 platform
* Maintaining hardcoded x86 compilation creates unnecessary complexity and potential build failures
* Modern Android development and testing workflows no longer require x86 support

# Changes

* Removed hardcoded i686(x86) compilation logic from Android debug build configuration
* Eliminated potential build conflicts and issues caused by unsupported platform targeting

# Impact

* Positive: Cleaner build process, reduced build complexity, eliminates potential x86-related build failures
* Breaking: None - x86 platform was already unsupported by Flutter

# Related

https://github.com/cunarist/rinf/issues/437